### PR TITLE
Version bump and removing operators removed from new haskell-gi-base

### DIFF
--- a/reactive-banana-gi-gtk/reactive-banana-gi-gtk.cabal
+++ b/reactive-banana-gi-gtk/reactive-banana-gi-gtk.cabal
@@ -15,11 +15,11 @@ library
   hs-source-dirs:      src
   exposed-modules:     Reactive.Banana.GI.Gtk
   build-depends:       base >= 4.7 && < 5,
-                       reactive-banana
-                     , gi-gtk
-                     , haskell-gi-base
-                     , transformers
-                     , text
+                       reactive-banana < 1.3
+                     , gi-gtk >= 3.0.1.1 && < 3.1
+                     , haskell-gi-base >= 0.20 && < 0.22
+                     , transformers >= 0.5.2.0 && < 0.6
+                     , text >= 1.2.2.1 && < 1.3
   default-language:    Haskell2010
 
 test-suite reactive-banana-gi-gtk-test

--- a/reactive-banana-gi-gtk/src/Reactive/Banana/GI/Gtk.hs
+++ b/reactive-banana-gi-gtk/src/Reactive/Banana/GI/Gtk.hs
@@ -232,41 +232,10 @@ data AttrOpBehavior self tag where
         -> Behavior (a -> IO b)
         -> AttrOpBehavior self tag
 
-    (::==)
-        ::
-            ( HasAttributeList self
-            , info ~ ResolveAttribute attr self
-            , AttrInfo info
-            , AttrBaseTypeConstraint info self
-            , tag ~ AttrSet
-            , AttrOpAllowed tag info self
-            , AttrSetTypeConstraint info b
-            )
-        => AttrLabelProxy (attr :: Symbol)
-        -> Behavior (self -> b)
-        -> AttrOpBehavior self tag
-
-    (::~~)
-        ::
-            ( HasAttributeList self
-            , info ~ ResolveAttribute attr self
-            , AttrInfo info
-            , AttrBaseTypeConstraint info self
-            , tag ~ AttrSet
-            , AttrOpAllowed AttrSet info self
-            , AttrOpAllowed AttrGet info self
-            , AttrSetTypeConstraint info b
-            , a ~ AttrGetType info
-            )
-        => AttrLabelProxy (attr :: Symbol)
-        -> Behavior (self -> a -> b)
-        -> AttrOpBehavior self tag
-
 infixr 0 :==
 infixr 0 :==>
 infixr 0 :~~
-infixr 0 ::==
-infixr 0 ::~~
+infixr 0 :~~>
 
 sink1 :: GObject self => self -> AttrOpBehavior self AttrSet -> MomentIO ()
 sink1 self (attr :== b) = do
@@ -289,16 +258,6 @@ sink1 self (attr :~~> b) = do
     liftIOLater $ set self [attr :~> x]
     e <- changes b
     reactimate' $ (fmap $ \x -> set self [attr :~> x]) <$> e
-sink1 self (attr ::== b) = do
-    x <- valueBLater b
-    liftIOLater $ set self [attr ::= x]
-    e <- changes b
-    reactimate' $ (fmap $ \x -> set self [attr ::= x]) <$> e
-sink1 self (attr ::~~ b) = do
-    x <- valueBLater b
-    liftIOLater $ set self [attr ::~ x]
-    e <- changes b
-    reactimate' $ (fmap $ \x -> set self [attr ::~ x]) <$> e
 
 -- "Animate" an attribute with a 'Reactive.Banana.Behavior'.
 --


### PR DESCRIPTION
Updates version bounds to current dependency version on Stackage, tested with latest GHC 8.4.2 and 8.4.1 Nightly snapshots.

In the process I also found that `haskell-gi-base` removed two operators from the `AttrOp` type in version 0.21.1, this change is reflected in the second commit.