### PR TITLE
Remove unnecessary `IO`

### DIFF
--- a/reactive-banana-gi-gtk/reactive-banana-gi-gtk.cabal
+++ b/reactive-banana-gi-gtk/reactive-banana-gi-gtk.cabal
@@ -17,7 +17,7 @@ library
   build-depends:       base >= 4.7 && < 5,
                        reactive-banana < 1.3
                      , gi-gtk >= 3.0.1.1 && < 5.0
-                     , haskell-gi-base >= 0.20 && < 0.26
+                     , haskell-gi-base >= 0.22 && < 0.26
                      , transformers >= 0.5.2.0 && < 0.6
                      , text >= 1.2.2.1 && < 1.3
   default-language:    Haskell2010


### PR DESCRIPTION
This PR removes the unnecessary `IO` from the return value of `signalAddHandler`. It isn't needed because the argument to the `AddHandler` constructor already is `IO`.

I took the liberty of updating the dependencies in the stack.yaml, because I needed a newer version of haskell-gi-base (>= 0.22) to access `disconnectSignalHandler`.

Since I changed the type of `signalAddHandler` this PR isn't backwards compatible. If you prefer to take a more compatible approach, like leaving the type of `signalAddHandler` unachanged and introducing the new type as something like `signalAddHandler'` or similar, just say so.